### PR TITLE
feat: Add option for custom palette in config

### DIFF
--- a/lua/everforest/colours.lua
+++ b/lua/everforest/colours.lua
@@ -188,7 +188,13 @@ M.generate_palette = function(options, theme)
     background_palette = medium_background[theme]
   end
 
-  return vim.tbl_extend("force", base, background_palette)
+  local custom_palette = {}
+
+  if options.palette ~= nil then
+    custom_palette = options.palette
+  end
+  
+  return vim.tbl_extend("force", base, background_palette, custom_palette)
 end
 
 return M


### PR DESCRIPTION
Closes #10 

Checks for palette in config and extends the returned palette.

As is, the keys of the custom palette would have to match the naming of the default palette and wouldn't support the hard/medium/soft variations. I'm open to adding that if you recommend.