### PR TITLE
Change color for symbols

### DIFF
--- a/lua/everforest/highlights.lua
+++ b/lua/everforest/highlights.lua
@@ -470,7 +470,7 @@ highlights.generate_syntax = function(palette, options)
     TSStringEscape = { link = "Green" },
     TSStringRegex = { link = "Green" },
     TSStringSpecial = { link = "SpecialChar" },
-    TSSymbol = { link = "Fg" },
+    TSSymbol = { link = "Aqua" },
     TSTag = { link = "Orange" },
     TSTagAttribute = { link = "Green" },
     TSTagDelimiter = { link = "Green" },


### PR DESCRIPTION
This small change will use `Agua` for symbols. Coding in ruby and having a lot of symbols makes the look of the color pink unpleasant IMO. 
Here is the look and feel in a screen short. Left are symbols in `Pink` and on the right are the symbols in `Agua`

<img width="1383" alt="image" src="https://github.com/neanias/everforest-nvim/assets/3010752/7d1f09d2-e88f-4c05-ae66-6e1ae5a708f1">
 