### PR TITLE
fix: update highlight groups for ggandor/leap.nvim

### DIFF
--- a/lua/everforest/highlights.lua
+++ b/lua/everforest/highlights.lua
@@ -1218,8 +1218,7 @@ highlights.generate_syntax = function(palette, options)
 
     -- ggandor/leap.nvim
     LeapMatch = syntax_entry(palette.fg, palette.purple, { styles.bold }),
-    LeapLabelPrimary = syntax_entry(palette.purple, palette.none, { styles.bold }),
-    LeapLabelSecondary = syntax_entry(palette.green, palette.none, { styles.bold }),
+    LeapLabel = syntax_entry(palette.purple, palette.none, { styles.bold }),
     LeapBackdrop = syntax_entry(palette.grey1, palette.none),
 
     -- lukas-reineke/indent-blankline.nvim


### PR DESCRIPTION
Highlight groups for Leap were simplified in [commit b75a86f](https://github.com/ggandor/leap.nvim/commit/b75a86f14ebdb3940460bfd1a02224210eccc698): `LeapLabelPrimary` and `LeapLabelSecondary` were replaced with a single `LeapLabel`. 

For a while, `LeapLabelPrimary` was kept as an alias for `LeapLabel`, but that seems to have stopped working at some point, and use of `LeapLabel` is now required for proper highlighting to take effect.