### PR TITLE
feat(highlights): Add option to customize CurrentWord style

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ require("everforest").setup({
   ---
   ---Options are `"none"` or `"dimmed"`.
   inlay_hints_background = "none",
+  ---Style used for the `CurrentWord` highlight group. Can be a string or a list of strings.
+  ---Valid options are: "bold", "italic", "reverse", "underline", "undercurl", "strikethrough".
+  ---Default is "bold".
+  current_word_style = "bold",
   ---You can override specific highlights to use other groups or a hex colour.
   ---This function will be called with the highlights and colour palette tables.
   ---@param highlight_groups Highlights
@@ -306,7 +310,7 @@ list of plugins that have highlights.
   - [x] `spell_foreground`
   - [x] `ui_contrast`
   - [x] `show_eob`
-  - [ ] `current_word`
+  - [x] `current_word`
   - [x] `diagnostic_text_highlight`
   - [x] `diagnostic_line_highlight`
   - [x] `diagnostic_virtual_text`

--- a/lua/everforest.lua
+++ b/lua/everforest.lua
@@ -81,8 +81,8 @@ M.config = {
   inlay_hints_background = "none",
   ---Style used for the `CurrentWord` highlight group. Can be a string or a list of strings.
   ---Valid options are: "bold", "italic", "reverse", "underline", "undercurl", "strikethrough".
-  ---Default is "underline".
-  current_word_style = "underline",
+  ---Default is "bold".
+  current_word_style = "bold",
   ---You can override specific highlights to use other groups or a hex colour.
   ---This function will be called with the highlights and colour palette tables.
   ---@param highlight_groups Highlights

--- a/lua/everforest.lua
+++ b/lua/everforest.lua
@@ -79,6 +79,10 @@ M.config = {
   ---
   ---Options are `"none"` or `"dimmed"`.
   inlay_hints_background = "none",
+  ---Style used for the `CurrentWord` highlight group. Can be a string or a list of strings.
+  ---Valid options are: "bold", "italic", "reverse", "underline", "undercurl", "strikethrough".
+  ---Default is "underline".
+  current_word_style = "underline",
   ---You can override specific highlights to use other groups or a hex colour.
   ---This function will be called with the highlights and colour palette tables.
   ---@param highlight_groups Highlights

--- a/lua/everforest/highlights.lua
+++ b/lua/everforest/highlights.lua
@@ -424,7 +424,25 @@ highlights.generate_syntax = function(palette, options)
     WarningFloat = syntax_entry(palette.yellow, palette.none),
     InfoFloat = syntax_entry(palette.blue, palette.none),
     HintFloat = syntax_entry(palette.green, palette.none),
-    CurrentWord = syntax_entry(palette.none, palette.none, { styles.bold }),
+    CurrentWord = (function()
+      local current_word_style_option = options.current_word_style or "bold"
+      local current_word_styles = {}
+      if type(current_word_style_option) == "string" then
+        if styles[current_word_style_option] then
+          table.insert(current_word_styles, styles[current_word_style_option])
+        end
+      elseif type(current_word_style_option) == "table" then
+        for _, style_name in ipairs(current_word_style_option) do
+          if styles[style_name] then
+            table.insert(current_word_styles, styles[style_name])
+          end
+        end
+      end
+      if #current_word_styles == 0 and styles["bold"] then
+        table.insert(current_word_styles, styles["bold"])
+      end
+      return syntax_entry(palette.none, palette.none, current_word_styles)
+    end)(),
 
     -- Git commit colours
     gitcommitSummary = { link = "Green" },


### PR DESCRIPTION
Adds a new configuration option `current_word_style` to allow users to customize the styling of the `CurrentWord` highlight group.

This is especially useful if the default font one uses is bold (as I do), which would mean that the `CurrentWord` highlight would not be visible.

This highlight group is commonly used for features like LSP references.

The option accepts a single string or a list of strings from the following:
- "bold"
- "italic"
- "reverse"
- "underline"
- "undercurl"
- "strikethrough"

The default style is still `bold`.

See the README for documentation on the new option.