### PR TITLE
feat(agentic.nvim): add agentic.nvim exposed highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 A Lua port of the [everforest](https://github.com/sainnhe/everforest) colour
 scheme.
 
-||Dark|Light|
-|:-:|:-:|:-:|
-|**Hard**|![everforest colour scheme dark hard](https://github.com/neanias/everforest-nvim/assets/5786847/5a60315f-9311-4474-8a80-f2251344cc3a)|![eveforest colour scheme light hard](https://github.com/neanias/everforest-nvim/assets/5786847/acc83044-c9ec-4335-a1ab-2e5f3c9e7429)|
-|**Medium** (default)|![eveforest colour scheme dark medium](https://github.com/neanias/everforest-nvim/assets/5786847/7094683a-1030-4cfe-b573-210f0b7863b1)|![everforest colour scheme light medium](https://github.com/neanias/everforest-nvim/assets/5786847/cccd5514-40ff-4155-b264-ceeba7b40ebf)|
-|**Soft**|![everforest colour scheme dark soft](https://github.com/neanias/everforest-nvim/assets/5786847/affeb2a7-d934-4c55-a946-d03da01f389a)|![everforest colour scheme light soft](https://github.com/neanias/everforest-nvim/assets/5786847/570e23b2-0515-499b-a257-5a8afe80082e)|
+|                      |                                                                  Dark                                                                  |                                                                  Light                                                                   |
+| :------------------: | :------------------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------: |
+|       **Hard**       | ![everforest colour scheme dark hard](https://github.com/neanias/everforest-nvim/assets/5786847/5a60315f-9311-4474-8a80-f2251344cc3a)  |  ![eveforest colour scheme light hard](https://github.com/neanias/everforest-nvim/assets/5786847/acc83044-c9ec-4335-a1ab-2e5f3c9e7429)   |
+| **Medium** (default) | ![eveforest colour scheme dark medium](https://github.com/neanias/everforest-nvim/assets/5786847/7094683a-1030-4cfe-b573-210f0b7863b1) | ![everforest colour scheme light medium](https://github.com/neanias/everforest-nvim/assets/5786847/cccd5514-40ff-4155-b264-ceeba7b40ebf) |
+|       **Soft**       | ![everforest colour scheme dark soft](https://github.com/neanias/everforest-nvim/assets/5786847/affeb2a7-d934-4c55-a946-d03da01f389a)  |  ![everforest colour scheme light soft](https://github.com/neanias/everforest-nvim/assets/5786847/570e23b2-0515-499b-a257-5a8afe80082e)  |
 
 _All screenshots taken from [my personal config](https://github.com/neanias/config/blob/main/nvim/lua/settings/plugins/everforest.lua)_
 
@@ -271,16 +271,17 @@ require("everforest").setup({
 - [Trouble](https://github.com/folke/trouble.nvim)
 - [WhichKey](https://github.com/folke/which-key.nvim)
 - [aerial.nvim](https://github.com/stevearc/aerial.nvim)
+- [agentic.nvim](https://github.com/carlos-algms/agentic.nvim)
 - [blamer.nvim](https://github.com/APZelos/blamer.nvim)
-- [fzf.vim](https://github.com/junegunn/fzf.vim)
 - [fsread.nvim](https://github.com/nullchilly/fsread.nvim)
+- [fzf.vim](https://github.com/junegunn/fzf.vim)
 - [lightspeed.nvim](https://github.com/ggandor/lightspeed.nvim)
 - [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
 - [nvim-dap-ui](https://github.com/rcarriga/nvim-dap-ui)
 - [nvim-navic](https://github.com/SmiteshP/nvim-navic)
 - [nvim-notify](https://github.com/rcarriga/nvim-notify)
-- [nvim-ts-rainbow](https://github.com/p00f/nvim-ts-rainbow)
 - [nvim-ts-rainbow2](https://github.com/HiPhish/nvim-ts-rainbow2)
+- [nvim-ts-rainbow](https://github.com/p00f/nvim-ts-rainbow)
 - [packer.nvim](https://github.com/wbthomason/packer.nvim)
 - [symbols-outline.nvim](https://github.com/simrat39/symbols-outline.nvim)
 - [undotree](https://github.com/mbbill/undotree)

--- a/lua/everforest/highlights.lua
+++ b/lua/everforest/highlights.lua
@@ -1866,11 +1866,8 @@ highlights.generate_syntax = function(palette, options)
     FSSuffix = syntax_entry(palette.grey1, palette.none),
 
     -- carlos-algms/agentic.nvim
-    AgenticCodeBlockFence = { link = "Directory" },
-    AgenticDiffAdd = { link = "DiffAdd" },
     AgenticDiffAddWord = syntax_entry(palette.bg0, palette.bg_green, { styles.bold }),
     AgenticDiffDeleteWord = syntax_entry(palette.bg0, palette.bg_red, { styles.bold }),
-    AgenticSpinnerBusy = { link = "Comment" },
     AgenticSpinnerGenerating = syntax_entry(palette.blue, palette.none, { styles.bold }),
     AgenticSpinnerSearching = syntax_entry(palette.yellow, palette.none, { styles.bold }),
     AgenticSpinnerThinking = syntax_entry(palette.purple, palette.none, { styles.bold }),

--- a/lua/everforest/highlights.lua
+++ b/lua/everforest/highlights.lua
@@ -1864,6 +1864,21 @@ highlights.generate_syntax = function(palette, options)
     FSPrefix = syntax_entry(palette.fg, transparency_respecting_colour(palette.bg0), { styles.bold }),
     FSSuffix = syntax_entry(palette.grey1, palette.none),
 
+    -- carlos-algms/agentic.nvim
+    AgenticCodeBlockFence = { link = "Directory" },
+    AgenticDiffAdd = { link = "DiffAdd" },
+    AgenticDiffAddWord = syntax_entry(palette.bg0, palette.bg_green, { styles.bold }),
+    AgenticDiffDeleteWord = syntax_entry(palette.bg0, palette.bg_red, { styles.bold }),
+    AgenticSpinnerBusy = { link = "Comment" },
+    AgenticSpinnerGenerating = syntax_entry(palette.blue, palette.none, { styles.bold }),
+    AgenticSpinnerSearching = syntax_entry(palette.yellow, palette.none, { styles.bold }),
+    AgenticSpinnerThinking = syntax_entry(palette.purple, palette.none, { styles.bold }),
+    AgenticStatusCompleted = syntax_entry(palette.bg0, palette.green),
+    AgenticStatusFailed = syntax_entry(palette.bg0, palette.red),
+    AgenticStatusPending = syntax_entry(palette.bg0, palette.purple),
+    AgenticThinking = syntax_entry(palette.bg0, palette.bg3),
+    AgenticTitle = syntax_entry(palette.bg0, palette.blue, { styles.bold }),
+
     -- Language specific settings
     -- Markdown
     markdownH1 = syntax_entry(palette.red, palette.none, { styles.bold }),


### PR DESCRIPTION
see: https://github.com/carlos-algms/agentic.nvim/pull/153

Hi @neanias , this PR adds support for agentic.nvim highlights that were currently missing.

<img width="1919" height="1024" alt="image" src="https://github.com/user-attachments/assets/0d12afb6-d61c-481d-90b5-d5d27a256282" />
<img width="1919" height="876" alt="image" src="https://github.com/user-attachments/assets/f55c3414-c73c-4903-ab3d-2b405dfeffc8" />
