### PR TITLE
Change SnacksPickerPathHidden to link to "grey" and not "NonText"

### DIFF
--- a/lua/everforest/highlights.lua
+++ b/lua/everforest/highlights.lua
@@ -1253,6 +1253,7 @@ highlights.generate_syntax = function(palette, options)
     SnacksPickerBufFlags = { link = "Grey" },
     SnacksPickerSelected = { link = "Aqua" },
     SnacksPickerKeymapRhs = { link = "Grey" },
+    SnacksPickerPathHidden = { link = "Grey" },
     -- }}}
 
     -- lewis6991/gitsigns.nvim


### PR DESCRIPTION
The Snacks explorer shows hidden files as `NonText`, which has way too low of contrast to be used comfortably. Solution doesn't necessarily have to be `grey1`, but anything darker than `bg5` is too dark.

Another solution is to change it based on `ui_contrast` value, but I notice the plugin support links to other values, rather than setting our own directly.

Before
<img width="332" height="228" alt="Screenshot 2026-04-06 at 3 10 36 AM" src="https://github.com/user-attachments/assets/ec3ee3b7-520e-4382-9de2-216c5becc52e" />

After
<img width="328" height="240" alt="Screenshot 2026-04-06 at 3 10 48 AM" src="https://github.com/user-attachments/assets/0876a841-2774-4135-99ed-5055fd718dbc" />

Snacks explorer is still missing full support such as NvimTree but this is good enough for now.